### PR TITLE
Fix parametrized url handling in relative_url_for

### DIFF
--- a/ckanext/report/helpers.py
+++ b/ckanext/report/helpers.py
@@ -27,7 +27,7 @@ def relative_url_for(**kwargs):
         for k, v in list(args.items()):
             if not v:
                 del args[k]
-        return tk.url_for(request.url_rule.rule, **args)
+        return tk.url_for(request.path, **args)
 
     else:
         args = dict(list(tk.request.environ['pylons.routes_dict'].items())


### PR DESCRIPTION
`request.url_rule.rule` contains parametrized parts like `<report_name>`. `request.path` has them filled correctly.