### PR TITLE
Support CKAN 2.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        ckan-version: [2.9, 2.9-py2, 2.8, 2.7]
+        ckan-version: ["2.10", 2.9, 2.9-py2, 2.8, 2.7]
       fail-fast: false
 
     name: CKAN ${{ matrix.ckan-version }}
@@ -28,7 +28,7 @@ jobs:
       image: openknowledge/ckan-dev:${{ matrix.ckan-version }}
     services:
       solr:
-        image: ckan/ckan-solr-dev:${{ matrix.ckan-version }}
+        image: ckan/ckan-solr:${{ matrix.ckan-version }}
       postgres:
         image: ckan/ckan-postgres-dev:${{ matrix.ckan-version }}
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
         with:
           python-version: '3.6'
@@ -46,7 +46,7 @@ jobs:
       CKAN_REDIS_URL: redis://redis:6379/1
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install requirements
         run: |
           pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ TODO:
 | 2.6 and earlier | yes                 |
 | 2.7             | yes                 |
 | 2.8             | yes                 |
-| 2.9             | yes                 |
+| 2.9-py2         | yes                 |
+| 2.9  (py3)      | yes                 |
+| 2.10 (py3)      | yes                 |
 
 Status: was in production at data.gov.uk around 2014-2016, but since that uses its own CSS rather than core CKAN's, for others to use it CSS needs adding. For an example, see this branch: see https://github.com/GSA/ckanext-report/tree/geoversion
 
@@ -41,7 +43,8 @@ Install ckanext-report into your CKAN virtual environment in the usual way:
 
 Initialize the database tables needed by ckanext-report:
 
-    (pyenv) $ paster --plugin=ckanext-report report initdb --config=mysite.ini
+    CKAN < 2.9  (pyenv) $ paster --plugin=ckanext-report report initdb --config=mysite.ini
+    CKAN >= 2.9 (pyenv) $ ckan -c mysite.ini report initdb
 
 Enable the plugin. In your config (e.g. development.ini or production.ini) add ``report`` to your ckan.plugins. e.g.:
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ data - other data values, as a dict
     <li>Average tags per package: {{ data['average_tags_per_package'] }} tags</li>
 </ul>
 
-<table class="table table-bordered table-condensed tablesorter" id="report-table" style="width: 100%; table-layout:fixed; margin-top: 8px;">
+<table class="table table-bordered table-condensed" id="report-table" style="width: 100%; table-layout:fixed; margin-top: 8px;">
     <thead>
       <tr>
         <th>Dataset</th>

--- a/ckanext/report/blueprint.py
+++ b/ckanext/report/blueprint.py
@@ -3,11 +3,12 @@ import json
 from flask import Blueprint, request, make_response
 
 import ckan.plugins.toolkit as t
-import ckan.lib.helpers as helpers
 from jinja2.exceptions import TemplateNotFound
 
 from ckanext.report.report_registry import Report
 from ckanext.report.lib import make_csv_from_dicts, ensure_data_is_dicts, anonymise_user_names
+from ckanext.report.helpers import relative_url_for
+
 
 import logging
 log = logging.getLogger(__name__)
@@ -37,15 +38,15 @@ def view(report_name, organization=None, refresh=False):
     rule = request.url_rule
     # ensure correct url is being used
     if 'organization' in rule.rule and 'organization' not in report['option_defaults']:
-        t.redirect_to(helpers.relative_url_for(organization=None))
+        t.redirect_to(relative_url_for(organization=None))
     elif 'organization' not in rule.rule and 'organization' in report['option_defaults'] and \
             report['option_defaults']['organization']:
         org = report['option_defaults']['organization']
-        t.redirect_to(helpers.relative_url_for(organization=org))
+        t.redirect_to(relative_url_for(organization=org))
     if 'organization' in t.request.params:
         # organization should only be in the url - let the param overwrite
         # the url.
-        t.redirect_to(helpers.relative_url_for())
+        t.redirect_to(relative_url_for())
 
     # options
     options = Report.add_defaults_to_options(t.request.params, report['option_defaults'])
@@ -92,7 +93,7 @@ def view(report_name, organization=None, refresh=False):
         except t.NotAuthorized:
             t.abort(401)
         # Don't want the refresh=1 in the url once it is done
-        t.redirect_to(helpers.relative_url_for(refresh=None))
+        t.redirect_to(relative_url_for(refresh=None))
 
     # Check for any options not allowed by the report
     for key in options:
@@ -141,7 +142,7 @@ def view(report_name, organization=None, refresh=False):
 
 
 report.add_url_rule(u'/report', view_func=index)
-report.add_url_rule(u'/report/<report_name>', view_func=view)
+report.add_url_rule(u'/report/<report_name>', view_func=view, methods=['GET', 'POST'])
 report.add_url_rule(u'/report/<report_name>/<organization>', view_func=view)
 
 

--- a/ckanext/report/blueprint.py
+++ b/ckanext/report/blueprint.py
@@ -1,6 +1,6 @@
 from builtins import str
 import json
-from flask import Blueprint, request
+from flask import Blueprint, request, make_response
 
 import ckan.plugins.toolkit as t
 import ckan.lib.helpers as helpers
@@ -115,13 +115,15 @@ def view(report_name, organization=None, refresh=False):
             except t.NotAuthorized:
                 t.abort(401)
             filename = 'report_%s.csv' % key
-            t.response.headers['Content-Type'] = 'application/csv'
-            t.response.headers['Content-Disposition'] = str('attachment; filename=%s' % (filename))
-            return make_csv_from_dicts(data['table'])
+            response = make_response(make_csv_from_dicts(data['table']))
+            response.headers['Content-Type'] = 'application/csv'
+            response.headers['Content-Disposition'] = str('attachment; filename=%s' % (filename))
+            return response
         elif format == 'json':
-            t.response.headers['Content-Type'] = 'application/json'
             data['generated_at'] = report_date
-            return json.dumps(data)
+            response = make_response(json.dumps(data))
+            response.headers['Content-Type'] = 'application/json'
+            return response
         else:
             t.abort(400, 'Format not known - try html, json or csv')
 

--- a/ckanext/report/lib.py
+++ b/ckanext/report/lib.py
@@ -1,7 +1,7 @@
 '''
 These functions are for use by other extensions for their reports.
 '''
-from builtins import str
+import six
 import ckan.plugins as p
 from past.builtins import basestring
 from collections import OrderedDict
@@ -70,7 +70,10 @@ def percent(numerator, denominator):
 
 def make_csv_from_dicts(rows):
     import csv
-    import io as StringIO
+    if six.PY2:
+        import cStringIO as StringIO
+    else:
+        import io as StringIO
 
     csvout = StringIO.StringIO()
     csvwriter = csv.writer(

--- a/ckanext/report/lib.py
+++ b/ckanext/report/lib.py
@@ -1,7 +1,7 @@
 '''
 These functions are for use by other extensions for their reports.
 '''
-
+from builtins import str
 import ckan.plugins as p
 from past.builtins import basestring
 from collections import OrderedDict
@@ -70,7 +70,7 @@ def percent(numerator, denominator):
 
 def make_csv_from_dicts(rows):
     import csv
-    import cStringIO as StringIO
+    import io as StringIO
 
     csvout = StringIO.StringIO()
     csvwriter = csv.writer(
@@ -93,14 +93,14 @@ def make_csv_from_dicts(rows):
         items = []
         for header in headers_ordered:
             item = row.get(header, 'no record')
-            if isinstance(item, datetime.datetime):
+            if isinstance(item, datetime):
                 item = item.strftime('%Y-%m-%d %H:%M')
             elif isinstance(item, (int, float, list, tuple)):
                 item = str(item)
             elif item is None:
                 item = ''
             else:
-                item = item.encode('utf8')
+                item = str(item)
             items.append(item)
         try:
             csvwriter.writerow(items)

--- a/ckanext/report/plugin/__init__.py
+++ b/ckanext/report/plugin/__init__.py
@@ -15,7 +15,6 @@ else:
 
 
 class ReportPlugin(MixinPlugin, p.SingletonPlugin):
-    p.implements(p.IRoutes, inherit=True)
     p.implements(p.IConfigurer)
     p.implements(p.ITemplateHelpers)
     p.implements(p.IActions, inherit=True)

--- a/ckanext/report/templates/report/tagless-datasets.html
+++ b/ckanext/report/templates/report/tagless-datasets.html
@@ -12,7 +12,7 @@ data - other data values, as a dict
     <li>{% trans %}Average tags per package{% endtrans %}: {{ data['average_tags_per_package'] }} tags</li>
 </ul>
 
-<table class="table table-bordered table-condensed tablesorter" id="report-table" style="width: 100%; table-layout:fixed; margin-top: 8px;">
+<table class="table table-bordered table-condensed" id="report-table" style="width: 100%; table-layout:fixed; margin-top: 8px;">
     <thead>
       <tr>
         <th>{% trans %}Dataset{% endtrans %}</th>

--- a/ckanext/report/templates/report/view.html
+++ b/ckanext/report/templates/report/view.html
@@ -57,24 +57,3 @@
       {% endif %}
   </div>
 {% endblock%}
-
-{% block scripts %}
-    {{ super() }}
-    <!--! Tablesorter allows table sorting by clicking on each column -->
-    <script type="text/javascript" src="/scripts/vendor/jquery.tablesorter.min.js"></script>
-    <script type="text/javascript">
-      //<![CDATA[
-      $(document).ready(function()
-        {
-          $("#report-table").tablesorter({
-              dateFormat: "uk",
-          });
-          $(".js-auto-submit").change(function () {
-              $(this).closest("form").submit();
-          });
-        }
-      );
-    // ]]>
-    </script>
-{% endblock%}
-

--- a/ckanext/report/tests/test_plugin.py
+++ b/ckanext/report/tests/test_plugin.py
@@ -1,6 +1,6 @@
 import pytest
 import six
-
+from ckan.plugins import toolkit as tk
 from ckan.tests import factories
 import ckanext.report.model as report_model
 
@@ -10,6 +10,15 @@ def _assert_in_body(string, response):
         assert string in response.body.decode('utf8')
     else:
         assert string in response.body
+
+
+def _assert_status(res, code_int):
+    if hasattr(res, 'status_code'):
+        assert res.status_code == code_int
+    elif hasattr(res, 'status_int'):
+        assert res.status_int == code_int
+    else:
+        raise NotImplementedError('No status for response')
 
 
 @pytest.fixture
@@ -42,3 +51,33 @@ class TestReportPlugin(object):
 
         _assert_in_body(u"Datasets which have no tags.", res)
         _assert_in_body('href="/dataset/' + dataset['name'] + '"', res)
+
+    def test_tagless_report_csv(self, app):
+        u"""Test tagless report generation"""
+        dataset1 = factories.Dataset()  # noqa F841
+        dataset2 = factories.Dataset()  # noqa F841
+
+        res = app.get(u'/report/tagless-datasets?format=csv')
+        _assert_status(res, 200)
+
+    def test_tagless_report_json(self, app):
+        u"""Test tagless report generation"""
+        dataset1 = factories.Dataset()  # noqa F841
+        dataset2 = factories.Dataset()  # noqa F841
+        res = app.get(u'/report/tagless-datasets?format=json')
+        _assert_status(res, 200)
+
+    def test_tagless_report_refresh_ok(self, app):
+        u"""Test tagless refresh report"""
+        user = factories.Sysadmin()
+        dataset = factories.Dataset()  # noqa F841
+        env = {'REMOTE_USER': user['name'].encode('ascii')}
+
+        res = app.post('/report/tagless-datasets', extra_environ=env)
+
+        # for CKAN >= 2.9, the response is not a redirect
+        if tk.check_ckan_version(min_version="2.9.0"):
+            _assert_status(res, 200)
+        else:
+            _assert_status(res, 302)
+            assert res.headers.get('Location') == 'http://localhost:5000/report/tagless-datasets'


### PR DESCRIPTION
Related to [CKAN#6787](https://github.com/ckan/ckan/issues/6787)

This PR:
 - Update responses for CSV and JSON
 - Fixes references to custom `relative_url_for` function
 - Removes broken old JS code
 - Tests added for failing endpoints

Looks good. Also tested locally with `ckanext-archiver` and `ckanext-qa` extensions 

![image](https://user-images.githubusercontent.com/3237309/164078912-cfc1a6bb-eff0-4b9d-b645-89e73aee7435.png)

![image](https://user-images.githubusercontent.com/3237309/164079524-308472e1-5dd6-4add-8179-7225207f7ea6.png)

![image](https://user-images.githubusercontent.com/3237309/164079567-9be3e2dc-8382-4433-9ca7-3866915b917e.png)
