### PR TITLE
Restore removed js-auto-submit to re-enable option controls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.8'
       - name: Install requirements
         run: pip install flake8 pycodestyle
       - name: Check syntax

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        ckan-version: ["2.10", 2.9, 2.9-py2, 2.8, 2.7]
+        ckan-version: ["2.10", 2.9, 2.9-py2, 2.8]
       fail-fast: false
 
     name: CKAN ${{ matrix.ckan-version }}

--- a/ckanext/report/assets/report.js
+++ b/ckanext/report/assets/report.js
@@ -1,0 +1,8 @@
+$(document).ready(function()
+    {
+        $(".js-auto-submit").change(function () {
+            console.log('foo')
+            $(this).closest("form").submit();
+        });
+    }
+);

--- a/ckanext/report/assets/webassets.yml
+++ b/ckanext/report/assets/webassets.yml
@@ -1,0 +1,8 @@
+report_js:
+  filter: rjsmin
+  output: ckanext-report/%(version)s_-main.js
+  extra:
+    preload:
+      - base/main
+  contents:
+    - report.js

--- a/ckanext/report/plugin/__init__.py
+++ b/ckanext/report/plugin/__init__.py
@@ -24,6 +24,7 @@ class ReportPlugin(MixinPlugin, p.SingletonPlugin):
 
     def update_config(self, config):
         p.toolkit.add_template_directory(config, '../templates')
+        p.toolkit.add_resource('../assets', 'report')
 
     # ITemplateHelpers
 

--- a/ckanext/report/templates/report/report_js_asset.html
+++ b/ckanext/report/templates/report/report_js_asset.html
@@ -1,0 +1,1 @@
+{% asset 'report/report_js' %}

--- a/ckanext/report/templates/report/report_js_resource.html
+++ b/ckanext/report/templates/report/report_js_resource.html
@@ -1,0 +1,1 @@
+{% resource "report/report.js" %}

--- a/ckanext/report/templates/report/view.html
+++ b/ckanext/report/templates/report/view.html
@@ -8,6 +8,8 @@
 {% endblock%}
 
 {% block primary_content_inner %}
+  {% set type = 'asset' if h.check_ckan_version(min_version="2.9.0", max_version="3.0.0") else 'resource' %}
+  {% include 'report/report_js_' ~ type ~ '.html' %}
       <h1>{{ report.title }}</h1>
       <p>{{ report.description }}</p>
       <p>


### PR DESCRIPTION
js-auto-submit was accidentally removed as part of the tablesorter removal which stopped all the report option-controls from working