### PR TITLE
Add max_age_in_days default 2 for cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Enable the plugin. In your config (e.g. development.ini or production.ini) add `
 
     ckan.plugins = report
 
+(Optional) Set max age to avoid stale cache. In the CKAN config add ``ckanext-report.max_age_in_days`` and assign an integer value. Default is 2 days. e.g.:
+
+    ckanext-report.max_age_in_days = 2
+
 
 ## Command-line interface
 


### PR DESCRIPTION
This is to give user the flexibility on how long the cache will live before it is considered stale and needs to be refreshed.

Previous it is set as a fixed 2-day. This PR allows user configure it in CKAN config by giving `ckanext-report.max_age_in_days` an integer value. 0 means the cache is refreshed on each request. Default is the same 2 days as before so no impact on upgrading users. 